### PR TITLE
Add deleted functionalotyu from blueeyed

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,13 +58,12 @@ Add the following to your `~/.tmux.conf` file:
 ``` tmux
 # Smart pane switching with awareness of Vim splits.
 # See: https://github.com/christoomey/vim-tmux-navigator
-is_vim="ps -o state= -o comm= -t '#{pane_tty}' \
-    | grep -iqE '^[^TXZ ]+ +(\\S+\\/)?g?(view|n?vim?x?)(diff)?$'"
-bind-key -n C-h if-shell "$is_vim" "send-keys C-h"  "select-pane -L"
-bind-key -n C-j if-shell "$is_vim" "send-keys C-j"  "select-pane -D"
-bind-key -n C-k if-shell "$is_vim" "send-keys C-k"  "select-pane -U"
-bind-key -n C-l if-shell "$is_vim" "send-keys C-l"  "select-pane -R"
-bind-key -n C-\ if-shell "$is_vim" "send-keys C-\\" "select-pane -l"
+bind-key -n C-h if-shell -F '#{m:*-#{pane_id}-*,#{@tmux_navigator}}' 'send-keys C-h' 'select-pane -L'
+bind-key -n C-j if-shell -F '#{m:*-#{pane_id}-*,#{@tmux_navigator}}' 'send-keys C-j' 'select-pane -D'
+bind-key -n C-k if-shell -F '#{m:*-#{pane_id}-*,#{@tmux_navigator}}' 'send-keys C-k' 'select-pane -U'
+bind-key -n C-l if-shell -F '#{m:*-#{pane_id}-*,#{@tmux_navigator}}' 'send-keys C-l' 'select-pane -R'
+bind-key -n C-\ if-shell -F '#{m:*-#{pane_id}-*,#{@tmux_navigator}}' 'send-keys C-\\' 'select-pane -l'
+
 bind-key -T copy-mode-vi C-h select-pane -L
 bind-key -T copy-mode-vi C-j select-pane -D
 bind-key -T copy-mode-vi C-k select-pane -U
@@ -245,12 +244,6 @@ Consider moving code from your shell's non-interactive rc file (e.g.,
 `~/.zshenv`) into the interactive startup file (e.g., `~/.zshrc`) as Vim only
 sources the non-interactive config.
 
-### It doesn't work in Vim's `terminal` mode
-
-Terminal mode is currently unsupported as adding this plugin's mappings there
-causes conflict with movement mappings for FZF (it also uses terminal mode).
-There's a conversation about this in https://github.com/christoomey/vim-tmux-navigator/pull/172
-
 ### It Doesn't Work in tmate
 
 [tmate][] is a tmux fork that aids in setting up remote pair programming
@@ -261,6 +254,32 @@ issue](https://github.com/christoomey/vim-tmux-navigator/issues/27) for more
 detail.
 
 [tmate]: http://tmate.io/
+
+### It Doesn't Work in Neovim (specifically C-h)
+
+[Neovim][] is a Vim fork. While Neovim is intended to be a drop-in replacement
+for Vim, it does handle some keyboard input differently than Vim does. Some
+users (including those on OS X) may find that all of their pane-switching
+keybindings work with the exception of <kbd>Ctrl</kbd>+<kbd>h</kbd>, which
+instead returns a backspace. The explanation of what is going on vastly exceeds
+the scope of this guide, but you can read the discussion on this Neovim
+[issue][].
+
+The simplest and hackiest solution is to add the following to your Neovim
+`init.vim`, capturing the <kbd>Backspace</kbd> that Neovim receives when
+<kbd>Ctrl</kbd>+<kbd>h</kbd> is typed in normal mode:
+
+```vimL
+nnoremap <silent> <BS> :TmuxNavigateLeft<cr>
+```
+
+A more complete and less-hacky solution would be to update the incorrect
+terminfo entry that is part of the problem on OS X (and some Linux
+distributions) as described in this [comment][].
+
+[Neovim]: https://neovim.io/
+[issue]: https://github.com/neovim/neovim/issues/2048
+[comment]: https://github.com/neovim/neovim/issues/2048#issuecomment-78045837
 
 ### It Still Doesn't Work!!!
 

--- a/doc/tmux-navigator.txt
+++ b/doc/tmux-navigator.txt
@@ -21,9 +21,6 @@ CONFIGURATION                             *tmux-navigator-configuration*
 * Activate autoupdate on exit
  let g:tmux_navigator_save_on_switch = 1
 
-* Disable vim->tmux navigation when the Vim pane is zoomed in tmux
- let g:tmux_navigator_disable_when_zoomed = 1
-
 * Custom Key Bindings
  let g:tmux_navigator_no_mappings = 1
 

--- a/vim-tmux-navigator.tmux
+++ b/vim-tmux-navigator.tmux
@@ -1,12 +1,11 @@
 #!/usr/bin/env bash
 
-is_vim="ps -o state= -o comm= -t '#{pane_tty}' \
-    | grep -iqE '^[^TXZ ]+ +(\\S+\\/)?g?(view|n?vim?x?)(diff)?$'"
-tmux bind-key -n C-h if-shell "$is_vim" "send-keys C-h"  "select-pane -L"
-tmux bind-key -n C-j if-shell "$is_vim" "send-keys C-j"  "select-pane -D"
-tmux bind-key -n C-k if-shell "$is_vim" "send-keys C-k"  "select-pane -U"
-tmux bind-key -n C-l if-shell "$is_vim" "send-keys C-l"  "select-pane -R"
-tmux bind-key -n C-\\ if-shell "$is_vim" "send-keys C-\\" "select-pane -l"
+tmux bind-key -n C-h if-shell -F '#{m:*-#{pane_id}-*,#{@tmux_navigator}}' "send-keys C-h" "select-pane -L"
+tmux bind-key -n C-j if-shell -F '#{m:*-#{pane_id}-*,#{@tmux_navigator}}' "send-keys C-j" "select-pane -D"
+tmux bind-key -n C-k if-shell -F '#{m:*-#{pane_id}-*,#{@tmux_navigator}}' "send-keys C-k" "select-pane -U"
+tmux bind-key -n C-l if-shell -F '#{m:*-#{pane_id}-*,#{@tmux_navigator}}' "send-keys C-l" "select-pane -R"
+tmux bind-key -n C-\\ if-shell -F '#{m:*-#{pane_id}-*,#{@tmux_navigator}}' "send-keys C-\\" "select-pane -l"
+
 tmux bind-key -T copy-mode-vi C-h select-pane -L
 tmux bind-key -T copy-mode-vi C-j select-pane -D
 tmux bind-key -T copy-mode-vi C-k select-pane -U


### PR DESCRIPTION
* @blueeyed deleted the indicator branch which I was using, when updating the plugins it can't because it has no reference to this repo's branch.
* This adds the branch and code that is needed to navigate through vim-splits and tmux-splits.